### PR TITLE
fixed opcache call 502 errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN sed -i "s/;date.timezone =.*/date.timezone = UTC/" /etc/php5/fpm/php.ini && 
     sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php5/fpm/php.ini && \
     sed -i "s/display_errors = Off/display_errors = stderr/" /etc/php5/fpm/php.ini && \
     sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 30M/" /etc/php5/fpm/php.ini && \
+    sed -i "s/;opcache.enable=0/opcache.enable=0/" /etc/php5/fpm/php.ini && \
     sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php5/fpm/php-fpm.conf && \
     sed -i '/^listen = /clisten = 9000' /etc/php5/fpm/pool.d/www.conf && \
     sed -i '/^listen.allowed_clients/c;listen.allowed_clients =' /etc/php5/fpm/pool.d/www.conf && \


### PR DESCRIPTION
it call 502 in nginx, some error like this bellow:
 May  2 11:33:49 ubuntu kernel: [148522.291772] php5-fpm[37887]: segfault at 2c ip 00000000006fbc7a sp 00007fffd9773590 error 4 in php5-fpm[400000+800000]
 
nginx error log:
2015/05/02 11:33:53 [error] 37819#0: *5 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 192.168.238.1, server: , request: "GET / HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "192.168.238.130"